### PR TITLE
docs: add 'release' kind option to pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,7 @@
 - [ ] /kind flake
 - [ ] /kind regression
 - [ ] /kind rollback
+- [ ] /kind release
 
 #### What this PR does / why we need it:
 


### PR DESCRIPTION

#### What type of PR is this?

- [ ] /kind bugfix
- [ ] /kind cleanup
- [x] /kind documentation
- [ ] /kind feature
- [ ] /kind refactor
- [ ] /kind dependency-update
- [ ] /kind api-change
- [ ] /kind deprecation
- [ ] /kind failing-test
- [ ] /kind flake
- [ ] /kind regression
- [ ] /kind rollback

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### How is this PR tested:
- [ ] unit test
- [ ] e2e test
- [ ] other (please specify)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
