### PR TITLE
feat: update label extraction and mapping in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
 
 #### What type of PR is this?
 
-- [ ] /kind bugfix
+- [ ] bug
 - [ ] /kind cleanup
-- [ ] /kind documentation
-- [ ] /kind feature
+- [ ] documentation
+- [ ] enhancement
 - [ ] /kind refactor
-- [ ] /kind dependency-update
+- [ ] dependencies
 - [ ] /kind api-change
 - [ ] /kind deprecation
 - [ ] /kind failing-test

--- a/auto/extract-kind-labels
+++ b/auto/extract-kind-labels
@@ -5,9 +5,38 @@ cd "$(dirname "$0")/.."
 
 pr_body="$1"
 
-labels=$(echo "$pr_body" | grep -iE '^\s*-\s*\[x\]\s*/kind\s+[a-zA-Z0-9_-]+' \
-  | sed -E 's@.*\/kind\s+([a-zA-Z0-9_-]+).*@kind/\1@' \
+# Extract /kind labels from checked boxes
+raw_labels=$(echo "$pr_body" | grep -iE '^\s*-\s*\[x\]\s*/kind\s+[a-zA-Z0-9_-]+' \
+  | sed -E 's@.*\/kind\s+([a-zA-Z0-9_-]+).*@\1@' \
   | sort -u | tr -d '\r')
+
+# Map /kind labels to actual labels
+labels=""
+for label in $raw_labels; do
+  case "$label" in
+    "bugfix")
+      mapped_label="bug"
+      ;;
+    "documentation")
+      mapped_label="documentation"
+      ;;
+    "feature")
+      mapped_label="enhancement"
+      ;;
+    "dependency-update")
+      mapped_label="dependencies"
+      ;;
+    *)
+      mapped_label="kind/$label"
+      ;;
+  esac
+
+  if [[ -n "$labels" ]]; then
+    labels="$labels"$'\n'"$mapped_label"
+  else
+    labels="$mapped_label"
+  fi
+done
 
 if [[ -n "$labels" ]]; then
   echo "labels<<EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION

#### What type of PR is this?

- [ ] /kind bugfix
- [ ] /kind cleanup
- [ ] /kind documentation
- [x] /kind feature
- [ ] /kind refactor
- [ ] /kind dependency-update
- [ ] /kind api-change
- [ ] /kind deprecation
- [ ] /kind failing-test
- [ ] /kind flake
- [ ] /kind regression
- [ ] /kind rollback
- [ ] /kind release

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### How is this PR tested:
- [ ] unit test
- [ ] e2e test
- [ ] other (please specify)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
