### PR TITLE
Revert "fix: Publish Docker Images after PR is merged"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - version.txt
     branches:
-      - main
+      - 'release/**'
 
 jobs:
   publish-docker-images:


### PR DESCRIPTION
Reverts ryougi-shiky/COMP30022-IT-Project#128

The aws e2e tests will be run on `release` branch, so we must run it on `release` branch...