### PR TITLE
fix: add nth-check override in package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,8 +62,6 @@
     "@testing-library/cypress": "^10.0.3",
     "cypress": "^14.4.1"
   },
-  // Override nth-check to address a known security vulnerability in earlier versions.
-  // See: https://github.com/advisories/GHSA-rp65-9cf3-cjxr
   "overrides": {
     "nth-check": "^2.1.1"
   }


### PR DESCRIPTION

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### What type of PR is this?

- [x] /kind bugfix
- [ ] /kind cleanup
- [ ] /kind documentation
- [ ] /kind feature
- [ ] /kind refactor
- [ ] /kind dependency-update
- [ ] /kind api-change
- [ ] /kind deprecation
- [ ] /kind failing-test
- [ ] /kind flake
- [ ] /kind regression
- [ ] /kind rollback
- [ ] /kind release

### How is this PR tested:
- [ ] unit test
- [x] e2e test
- [ ] other (please specify)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
