### PR TITLE
fix: force execute cy.clear and cy.type for preventing DOM rendering too fast

### DIFF
--- a/.github/workflows/run-e2e-test-on-aws-ecs.yml
+++ b/.github/workflows/run-e2e-test-on-aws-ecs.yml
@@ -59,7 +59,7 @@ jobs:
 
   deploy-app:
     runs-on: ubuntu-22.04
-    # if: startsWith(github.ref, 'refs/heads/release/') && github.event.inputs.confirm == 'YES'
+    if: startsWith(github.ref, 'refs/heads/release/') && github.event.inputs.confirm == 'YES'
     outputs:
       cluster_name: ${{ steps.tf-output.outputs.cluster_name }}
       service_name: ${{ steps.tf-output.outputs.service_name }}


### PR DESCRIPTION
- **fix: chain the check, clear, type**
- **fix: comment out conditional for deploy-app job**


### What this PR does / why we need it:
As I mentioned in last PR https://github.com/ryougi-shiky/COMP30022-IT-Project/pull/298
There was a issue that cy.type cannot locate on the target item. Last PR can pass the tests from local laptop running e2e tests on AWS resources but cannot pass on Github runners.
So we forced the functions to be executed, which is faster than the DOM rendering. I don't think this is a good solution. However we will use it for now. It might be fixed in the future...

### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### What type of PR is this?

- [x] /kind bugfix
- [ ] /kind cleanup
- [ ] /kind documentation
- [ ] /kind feature
- [ ] /kind refactor
- [ ] /kind dependency-update
- [ ] /kind api-change
- [ ] /kind deprecation
- [ ] /kind failing-test
- [ ] /kind flake
- [ ] /kind regression
- [ ] /kind rollback
- [ ] /kind release

### How is this PR tested:
- [ ] unit test
- [x] e2e test
- [ ] other (please specify)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
