### PR TITLE
chore(config): update cypress configuration and refine vite build settings

### DIFF
--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -3,6 +3,8 @@ const fs = require("fs");
 const path = require("path");
 
 module.exports = defineConfig({
+  allowCypressEnv: false,
+
   // Default timeout for most commands, can be overridden by env var
   defaultCommandTimeout: process.env.CYPRESS_DEFAULT_COMMAND_TIMEOUT
     ? parseInt(process.env.CYPRESS_DEFAULT_COMMAND_TIMEOUT)
@@ -54,8 +56,5 @@ module.exports = defineConfig({
         }
       });
     },
-  },
-  env: {
-    // You can add other environment variables here
   },
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -14,5 +14,6 @@ export default defineConfig({
   },
   build: {
     outDir: 'build',
+    chunkSizeWarningLimit: 1000,
   },
 });


### PR DESCRIPTION

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### What type of PR is this?

- [ ] /kind bugfix
- [x] /kind cleanup
- [ ] /kind documentation
- [ ] /kind feature
- [ ] /kind refactor
- [ ] /kind dependency-update
- [ ] /kind api-change
- [ ] /kind deprecation
- [ ] /kind failing-test
- [ ] /kind flake
- [ ] /kind regression
- [ ] /kind rollback
- [ ] /kind release

### How is this PR tested:
- [x] unit test
- [ ] e2e test
- [ ] other (please specify)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
